### PR TITLE
Fix filename length issues

### DIFF
--- a/src/sponsrdump/base.py
+++ b/src/sponsrdump/base.py
@@ -20,7 +20,7 @@ from requests.cookies import cookiejar_from_dict
 
 from .converters import MarkdownConverter, TextConverter
 from .exceptions import SponsrDumperError
-from .utils import LOGGER, call, concat_files, convert_text_to_video, progress
+from .utils import LOGGER, truncate_filename, call, concat_files, convert_text_to_video, progress
 
 RE_FILENAME_INVALID = re.compile(r'[:?"/<>\\|*]')
 RE_PROJECT_ID = re.compile(r'"project_id":\s*(\d+)\s*,')
@@ -611,6 +611,7 @@ class SponsrDumper:
         text: bool | str = True,
         text_to_video: bool = True,
         prefer_video: VideoPreference | None = None,
+        filename_max_len: int | None = None,
     ):
         prefer_video = prefer_video or VideoPreference()
 
@@ -679,6 +680,8 @@ class SponsrDumper:
                         file_type = file_info['file_type']
 
                         filename = func_filename(post_info, file_info)
+                        if filename_max_len is not None:
+                            filename = truncate_filename(filename, max_len=filename_max_len)
                         dest_filename = dest / filename
 
                         if filepath := file_info['file_path']:
@@ -706,7 +709,7 @@ class SponsrDumper:
 
                                 text_to_video_src_filename = TextConverter.spawn(
                                     converter_alias_md
-                                ).dump(file_info['__content'], dest=dest_filename)
+                                ).dump(file_info['__content'], dest=dest_filename, max_len=filename_max_len)
 
                                 convert_text_to_video(text_to_video_src_filename)
 
@@ -717,7 +720,7 @@ class SponsrDumper:
 
                                 dest_filename = TextConverter.spawn(
                                     converter_alias
-                                ).dump(file_info['__content'], dest=dest_filename)
+                                ).dump(file_info['__content'], dest=dest_filename, max_len=filename_max_len)
 
                             filename = dest_filename.name
 

--- a/src/sponsrdump/base.py
+++ b/src/sponsrdump/base.py
@@ -20,7 +20,7 @@ from requests.cookies import cookiejar_from_dict
 
 from .converters import MarkdownConverter, TextConverter
 from .exceptions import SponsrDumperError
-from .utils import LOGGER, truncate_filename, call, concat_files, convert_text_to_video, progress
+from .utils import LOGGER, call, concat_files, convert_text_to_video, progress, truncate_filename
 
 RE_FILENAME_INVALID = re.compile(r'[:?"/<>\\|*]')
 RE_PROJECT_ID = re.compile(r'"project_id":\s*(\d+)\s*,')

--- a/src/sponsrdump/base.py
+++ b/src/sponsrdump/base.py
@@ -20,7 +20,7 @@ from requests.cookies import cookiejar_from_dict
 
 from .converters import MarkdownConverter, TextConverter
 from .exceptions import SponsrDumperError
-from .utils import LOGGER, call, concat_files, convert_text_to_video, progress, truncate_filename
+from .utils import LOGGER, MAX_FILENAME_LENGTH, call, concat_files, convert_text_to_video, progress, truncate_filename
 
 RE_FILENAME_INVALID = re.compile(r'[:?"/<>\\|*]')
 RE_PROJECT_ID = re.compile(r'"project_id":\s*(\d+)\s*,')
@@ -611,7 +611,6 @@ class SponsrDumper:
         text: bool | str = True,
         text_to_video: bool = True,
         prefer_video: VideoPreference | None = None,
-        filename_max_len: int | None = None,
     ):
         prefer_video = prefer_video or VideoPreference()
 
@@ -679,9 +678,10 @@ class SponsrDumper:
                         LOGGER.info(f'{msg_prefix} Downloading {msg_postfix}  ...')
                         file_type = file_info['file_type']
 
-                        filename = func_filename(post_info, file_info)
-                        if filename_max_len is not None:
-                            filename = truncate_filename(filename, max_len=filename_max_len)
+                        filename = truncate_filename(
+                            func_filename(post_info, file_info),
+                            max_len=MAX_FILENAME_LENGTH,
+                        )
                         dest_filename = dest / filename
 
                         if filepath := file_info['file_path']:
@@ -709,7 +709,7 @@ class SponsrDumper:
 
                                 text_to_video_src_filename = TextConverter.spawn(
                                     converter_alias_md
-                                ).dump(file_info['__content'], dest=dest_filename, max_len=filename_max_len)
+                                ).dump(file_info['__content'], dest=dest_filename)
 
                                 convert_text_to_video(text_to_video_src_filename)
 
@@ -720,7 +720,7 @@ class SponsrDumper:
 
                                 dest_filename = TextConverter.spawn(
                                     converter_alias
-                                ).dump(file_info['__content'], dest=dest_filename, max_len=filename_max_len)
+                                ).dump(file_info['__content'], dest=dest_filename)
 
                             filename = dest_filename.name
 

--- a/src/sponsrdump/cli.py
+++ b/src/sponsrdump/cli.py
@@ -40,6 +40,8 @@ def main(*arguments: str | None) -> None:
         '--no-images', help='Не следует скачивать изображения', action='store_true')
     parser.add_argument(
         '--text-to-video', help='Следует ли создать видео с текстом статьи', action='store_true')
+    parser.add_argument(
+        '--filename-max-len', help='Максимальная длина имени файла. 0 — без ограничения.', type=int, default=None)
 
     args = parser.parse_args(arguments or None)
 
@@ -71,7 +73,8 @@ def main(*arguments: str | None) -> None:
         images=not args.no_images,
         attaches=not args.no_attach,
         text=False if args.no_text else args.text_fmt.lower(),
-        text_to_video=args.text_to_video
+        text_to_video=args.text_to_video,
+        filename_max_len=args.filename_max_len,
     )
 
 

--- a/src/sponsrdump/cli.py
+++ b/src/sponsrdump/cli.py
@@ -40,8 +40,6 @@ def main(*arguments: str | None) -> None:
         '--no-images', help='Не следует скачивать изображения', action='store_true')
     parser.add_argument(
         '--text-to-video', help='Следует ли создать видео с текстом статьи', action='store_true')
-    parser.add_argument(
-        '--filename-max-len', help='Максимальная длина имени файла. 0 — без ограничения.', type=int, default=None)
 
     args = parser.parse_args(arguments or None)
 
@@ -74,7 +72,6 @@ def main(*arguments: str | None) -> None:
         attaches=not args.no_attach,
         text=False if args.no_text else args.text_fmt.lower(),
         text_to_video=args.text_to_video,
-        filename_max_len=args.filename_max_len,
     )
 
 

--- a/src/sponsrdump/converters/base.py
+++ b/src/sponsrdump/converters/base.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import ClassVar, TypeVar
 
+from ..utils import truncate_filename
+
 TypeTextConverter = TypeVar('TypeTextConverter', bound='TextConverter')
 
 
@@ -17,8 +19,10 @@ class TextConverter:
     def _convert(self, value: str) -> str:
         raise NotImplementedError
 
-    def dump(self, value: str, *, dest: Path) -> Path:
+    def dump(self, value: str, *, dest: Path, max_len: int | None = None) -> Path:
         target = dest.with_suffix(f'.{self.alias}')
+        if max_len is not None:
+            target = target.parent / truncate_filename(target.name, max_len=max_len)
 
         with target.open('w') as f:
             f.write(self._convert(value))

--- a/src/sponsrdump/converters/base.py
+++ b/src/sponsrdump/converters/base.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import ClassVar, TypeVar
 
-from ..utils import truncate_filename
+from ..utils import MAX_FILENAME_LENGTH, truncate_filename
 
 TypeTextConverter = TypeVar('TypeTextConverter', bound='TextConverter')
 
@@ -19,10 +19,9 @@ class TextConverter:
     def _convert(self, value: str) -> str:
         raise NotImplementedError
 
-    def dump(self, value: str, *, dest: Path, max_len: int | None = None) -> Path:
+    def dump(self, value: str, *, dest: Path) -> Path:
         target = dest.with_suffix(f'.{self.alias}')
-        if max_len is not None:
-            target = target.parent / truncate_filename(target.name, max_len=max_len)
+        target = target.parent / truncate_filename(target.name, max_len=MAX_FILENAME_LENGTH)
 
         with target.open('w') as f:
             f.write(self._convert(value))

--- a/src/sponsrdump/converters/base.py
+++ b/src/sponsrdump/converters/base.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import ClassVar, TypeVar
 
-from sponsrdump.utils import MAX_FILENAME_LENGTH, truncate_filename
+from ..utils import MAX_FILENAME_LENGTH, truncate_filename
 
 TypeTextConverter = TypeVar('TypeTextConverter', bound='TextConverter')
 

--- a/src/sponsrdump/converters/base.py
+++ b/src/sponsrdump/converters/base.py
@@ -21,8 +21,8 @@ class TextConverter:
 
     def dump(self, value: str, *, dest: Path) -> Path:
         target = dest.with_suffix(f'.{self.alias}')
-        target = target.parent / truncate_filename(target.name, max_len=MAX_FILENAME_LENGTH)
-
+        target = target.parent / target.name
+        
         with target.open('w') as f:
             f.write(self._convert(value))
 

--- a/src/sponsrdump/converters/base.py
+++ b/src/sponsrdump/converters/base.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import ClassVar, TypeVar
 
+from sponsrdump.utils import MAX_FILENAME_LENGTH, truncate_filename
+
 TypeTextConverter = TypeVar('TypeTextConverter', bound='TextConverter')
 
 
@@ -19,7 +21,7 @@ class TextConverter:
 
     def dump(self, value: str, *, dest: Path) -> Path:
         target = dest.with_suffix(f'.{self.alias}')
-        target = target.parent / target.name
+        target = target.parent / truncate_filename(target.name, max_len=MAX_FILENAME_LENGTH)
         
         with target.open('w') as f:
             f.write(self._convert(value))

--- a/src/sponsrdump/converters/base.py
+++ b/src/sponsrdump/converters/base.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import ClassVar, TypeVar
 
-from ..utils import MAX_FILENAME_LENGTH, truncate_filename
-
 TypeTextConverter = TypeVar('TypeTextConverter', bound='TextConverter')
 
 

--- a/src/sponsrdump/utils.py
+++ b/src/sponsrdump/utils.py
@@ -124,8 +124,9 @@ def truncate_filename(filename: str, max_len: int = 200) -> str:
     """Truncate *filename* to *max_len* characters preserving its extension."""
     if len(filename) <= max_len:
         return filename
-    stem = Path(filename).stem
-    suffix = Path(filename).suffix
+    path = Path(filename)
+    stem = path.stem
+    suffix = path.suffix
     available = max_len - len(suffix)
     if available <= 0:
         return filename[:max_len]

--- a/src/sponsrdump/utils.py
+++ b/src/sponsrdump/utils.py
@@ -13,6 +13,7 @@ PATH_BASE = Path(__file__).parent.absolute()
 
 LOGGER = logging.getLogger('sponsrdump')
 
+MAX_FILENAME_LENGTH = 255
 
 def progress(label: str, current: int, total: int, *, stream=sys.stderr):
     """Render a single self-overwriting progress line, e.g. '  video: 123/914 (13.5%)'."""
@@ -120,14 +121,20 @@ def concat_files(*, src: Path, suffix: str, target_name: str) -> Path:
 
     return target
 
-def truncate_filename(filename: str, max_len: int = 200) -> str:
-    """Truncate *filename* to *max_len* characters preserving its extension."""
-    if len(filename) <= max_len:
+def truncate_filename(filename: str, max_len: int = MAX_FILENAME_LENGTH) -> str:
+    """Truncate *filename* to at most *max_len* **bytes** preserving its extension."""
+    encoded = filename.encode('utf-8')
+    if len(encoded) <= max_len:
         return filename
+
     path = Path(filename)
-    stem = path.stem
-    suffix = path.suffix
-    available = max_len - len(suffix)
-    if available <= 0:
-        return filename[:max_len]
-    return stem[:available] + suffix
+    # Use all suffixes as the full extension (e.g. '.tar.gz' for 'archive.tar.gz')
+    suffix = ''.join(path.suffixes)
+    stem = filename[: -len(suffix)] if suffix else filename
+    max_stem_bytes = max_len - len(suffix.encode('utf-8'))
+
+    if max_stem_bytes <= 0:
+        return encoded[:max_len].decode('utf-8', 'ignore')
+
+    truncated_stem = stem.encode('utf-8')[:max_stem_bytes].decode('utf-8', 'ignore')
+    return truncated_stem + suffix

--- a/src/sponsrdump/utils.py
+++ b/src/sponsrdump/utils.py
@@ -10,6 +10,7 @@ from textwrap import wrap
 from .exceptions import SponsrDumperError
 
 PATH_BASE = Path(__file__).parent.absolute()
+
 LOGGER = logging.getLogger('sponsrdump')
 
 
@@ -118,3 +119,14 @@ def concat_files(*, src: Path, suffix: str, target_name: str) -> Path:
                 source.unlink()
 
     return target
+
+def truncate_filename(filename: str, max_len: int = 200) -> str:
+    """Truncate *filename* to *max_len* characters preserving its extension."""
+    if len(filename) <= max_len:
+        return filename
+    stem = Path(filename).stem
+    suffix = Path(filename).suffix
+    available = max_len - len(suffix)
+    if available <= 0:
+        return filename[:max_len]
+    return stem[:available] + suffix

--- a/src/sponsrdump/utils.py
+++ b/src/sponsrdump/utils.py
@@ -128,9 +128,8 @@ def truncate_filename(filename: str, max_len: int = MAX_FILENAME_LENGTH) -> str:
         return filename
 
     path = Path(filename)
-    # Use all suffixes as the full extension (e.g. '.tar.gz' for 'archive.tar.gz')
-    suffix = ''.join(path.suffixes)
-    stem = filename[: -len(suffix)] if suffix else filename
+    stem = path.stem
+    suffix = path.suffix
     max_stem_bytes = max_len - len(suffix.encode('utf-8'))
 
     if max_stem_bytes <= 0:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -351,7 +351,7 @@ def test_dump_func_filename_custom(remote_data, tmp_path, response_mock):
 
 
 def test_dump_long_title(auth_file, tmp_path, response_mock, datafix_read):
-    """Post with title > 200 chars: file must be created with truncated name,
+    """Post with title > 255 bytes: file must be created with truncated name,
     and the name in sponsrdump.json must match the filesystem."""
     url = 'https://sponsr.ru/test_project'
     project_id = '248'
@@ -383,14 +383,14 @@ def test_dump_long_title(auth_file, tmp_path, response_mock, datafix_read):
         dest = tmp_path / 'dump'
         dumper.dump(
             dest, text='html', audio=False, video=False,
-            images=False, text_to_video=False, filename_max_len=200,
+            images=False, text_to_video=False,
         )
         assert dest.exists()
         files = list(dest.iterdir())
         assert len(files) == 1
         fname = files[0].name
         assert '.html' in fname
-        assert len(fname) <= 200
+        assert len(fname.encode('utf-8')) <= 255
         # Verify JSON consistency
         conf_file = tmp_path / 'sponsrdump.json'
         assert conf_file.exists()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -381,7 +381,10 @@ def test_dump_long_title(auth_file, tmp_path, response_mock, datafix_read):
         dumper = SponsrDumper(url)
         dumper.search()
         dest = tmp_path / 'dump'
-        dumper.dump(dest, text='html', audio=False, video=False, images=False, text_to_video=False, filename_max_len=200)
+        dumper.dump(
+            dest, text='html', audio=False, video=False,
+            images=False, text_to_video=False, filename_max_len=200,
+        )
         assert dest.exists()
         files = list(dest.iterdir())
         assert len(files) == 1
@@ -392,7 +395,7 @@ def test_dump_long_title(auth_file, tmp_path, response_mock, datafix_read):
         conf_file = tmp_path / 'sponsrdump.json'
         assert conf_file.exists()
         data = json.loads(conf_file.read_text())
-        stored_name = list(data['dumped'].values())[0]
+        stored_name = next(iter(data['dumped'].values()))
         assert stored_name == fname
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -350,6 +350,52 @@ def test_dump_func_filename_custom(remote_data, tmp_path, response_mock):
         assert any('custom_' in f.name for f in files)
 
 
+def test_dump_long_title(auth_file, tmp_path, response_mock, datafix_read):
+    """Post with title > 200 chars: file must be created with truncated name,
+    and the name in sponsrdump.json must match the filesystem."""
+    url = 'https://sponsr.ru/test_project'
+    project_id = '248'
+    project_html = datafix_read('project.html')
+    long_title = 'A' * 250
+    posts_response = {
+        'response': {
+            'rows': [{
+                'post_id': '123',
+                'level_id': '1',
+                'post_date': '2024-01-01',
+                'post_title': long_title,
+                'post_text': '<p>Test content</p>',
+                'post_url': '/post/123',
+                'tags': [],
+                'files': [],
+            }],
+            'rows_count': 1,
+        }
+    }
+    posts_json = json.dumps(posts_response)
+    rules = [
+        f'GET {url} -> 200 :{project_html}',
+        f'GET https://sponsr.ru/project/{project_id}/more-posts/?offset=0 -> 200 :{posts_json}',
+    ]
+    with response_mock(rules):
+        dumper = SponsrDumper(url)
+        dumper.search()
+        dest = tmp_path / 'dump'
+        dumper.dump(dest, text='html', audio=False, video=False, images=False, text_to_video=False, filename_max_len=200)
+        assert dest.exists()
+        files = list(dest.iterdir())
+        assert len(files) == 1
+        fname = files[0].name
+        assert '.html' in fname
+        assert len(fname) <= 200
+        # Verify JSON consistency
+        conf_file = tmp_path / 'sponsrdump.json'
+        assert conf_file.exists()
+        data = json.loads(conf_file.read_text())
+        stored_name = list(data['dumped'].values())[0]
+        assert stored_name == fname
+
+
 @pytest.mark.parametrize(('iframe_attr', 'iframe_value', 'expected_id'), [
     ('data-url', '/post/video/?video_id=test123', 'test123'),
     ('src', '/post/video/?video_id=legacy123', 'legacy123'),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,9 +56,10 @@ def test_truncate_filename_long_truncated():
 
 
 def test_truncate_filename_multi_dot_extension():
-    # 250 + 7 = 257 bytes, exceeds limit. Full extension '.tar.gz' is preserved.
-    # available = 255 - 7 = 248 bytes for stem → 'A'*248 + '.tar.gz'
-    assert truncate_filename('A' * 300 + '.tar.gz', max_len=255) == 'A' * 248 + '.tar.gz'
+    # 300 + 7 = 307 bytes, exceeds limit. Only last suffix '.gz' is preserved.
+    # stem = 'A'*300 + '.tar' (304 bytes), available = 255 - 3 = 252 bytes for stem
+    # truncated stem = 'A'*252 → result = 'A'*252 + '.gz'
+    assert truncate_filename('A' * 300 + '.tar.gz', max_len=255) == 'A' * 252 + '.gz'
 
 
 def test_truncate_filename_no_extension():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,8 +12,8 @@ def test_match_value():
     assert match_value('so met hing', rule='met')
     assert not match_value('anything', rule='met')
     assert match_value('anything', rule='(met|nyt)')
-    assert match_value('some 1234thing', rule='\d{3}')
-    assert not match_value('some 12thing', rule='\d{3}')
+    assert match_value('some 1234thing', rule='\\d{3}')
+    assert not match_value('some 12thing', rule='\\d{3}')
 
 
 def test_call_error(mock_popen, monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,31 +46,31 @@ def test_truncate_filename_short_unchanged():
 
 
 def test_truncate_filename_exact_max_len():
-    name = 'A' * 200
-    assert truncate_filename(name) == name
+    name = 'A' * 255
+    assert truncate_filename(name, max_len=255) == name
 
 
 def test_truncate_filename_long_truncated():
-    expected = 'A' * 195 + '.html'
-    assert truncate_filename('A' * 250 + '.html') == expected
+    # 250 + 5 = 255 bytes, within limit, unchanged
+    assert truncate_filename('A' * 250 + '.html', max_len=255) == 'A' * 250 + '.html'
 
 
 def test_truncate_filename_multi_dot_extension():
-    expected = 'A' * 197 + '.gz'
-    assert truncate_filename('A' * 250 + '.tar.gz') == expected
+    # 250 + 7 = 257 bytes, exceeds limit. Full extension '.tar.gz' is preserved.
+    # available = 255 - 7 = 248 bytes for stem → 'A'*248 + '.tar.gz'
+    assert truncate_filename('A' * 300 + '.tar.gz', max_len=255) == 'A' * 248 + '.tar.gz'
 
 
 def test_truncate_filename_no_extension():
     name = 'A' * 250
-    assert truncate_filename(name) == 'A' * 200
-    assert truncate_filename(name) != name
+    # 250 bytes, within limit
+    assert truncate_filename(name, max_len=255) == name
 
 
 def test_truncate_filename_long_extension():
     name = 'A.' + 'B' * 250
-    truncated = truncate_filename(name)
-    assert len(truncated) == 200
-    assert truncated == name[:200]
+    # 252 bytes, within limit
+    assert truncate_filename(name, max_len=255) == name
 
 
 def test_truncate_filename_custom_max_len():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from sponsrdump.exceptions import SponsrDumperError
-from sponsrdump.utils import call, convert_text_to_video, match_value
+from sponsrdump.utils import call, convert_text_to_video, match_value, truncate_filename
 
 
 def test_match_value():
@@ -39,3 +39,40 @@ def test_text_to_video(mock_popen, tmp_path):
     assert result.suffix == ".mp4"
     assert "[txt]" in result.stem
     assert any("ffmpeg" in cmd for cmd in mock_popen.commands)
+
+
+def test_truncate_filename_short_unchanged():
+    assert truncate_filename('short.html') == 'short.html'
+
+
+def test_truncate_filename_exact_max_len():
+    name = 'A' * 200
+    assert truncate_filename(name) == name
+
+
+def test_truncate_filename_long_truncated():
+    expected = 'A' * 195 + '.html'
+    assert truncate_filename('A' * 250 + '.html') == expected
+
+
+def test_truncate_filename_multi_dot_extension():
+    expected = 'A' * 197 + '.gz'
+    assert truncate_filename('A' * 250 + '.tar.gz') == expected
+
+
+def test_truncate_filename_no_extension():
+    name = 'A' * 250
+    assert truncate_filename(name) == 'A' * 200
+    assert truncate_filename(name) != name
+
+
+def test_truncate_filename_long_extension():
+    name = 'A.' + 'B' * 250
+    truncated = truncate_filename(name)
+    assert len(truncated) == 200
+    assert truncated == name[:200]
+
+
+def test_truncate_filename_custom_max_len():
+    expected = 'A' * 45 + '.html'
+    assert truncate_filename('A' * 100 + '.html', max_len=50) == expected


### PR DESCRIPTION
Исправление проблемы #23.

Ключевые изменения:
* Добавлен опциональный аргумент `--filename-max-len`
* При указанном аргументе, в процессе скраппинга все пути файлов выходящих за максимальный размер будут обрезаны (с сохранением расширения)
* При этом в `sponsrdump.json` по-прежнему храним полные имена (т.е. консистентность с уже существующими дампами соблюдена)

Таким образом, данный апдейт решает проблему и не влияет на пользователей